### PR TITLE
Prevent form submit if user is not logged in

### DIFF
--- a/modules/spielberg/src/components/winners/CategoryOption.tsx
+++ b/modules/spielberg/src/components/winners/CategoryOption.tsx
@@ -17,6 +17,7 @@ const CategoryOption: React.FC<Props> = ({ indication }) => {
     <label className="block bg-gray-800 w-full text-left p-4 flex items-center space-x-2">
       <input
         type={"radio"}
+        disabled={!loggedUser}
         {...register("indicationId")}
         value={indication.id}
         className="w-6 h-6 p-4"

--- a/modules/spielberg/src/components/winners/CategoryOptions.tsx
+++ b/modules/spielberg/src/components/winners/CategoryOptions.tsx
@@ -6,8 +6,9 @@ import { AxiosResponse } from "axios";
 import Loader from "react-loader-spinner";
 import useDefaultMutation from "../../utils/useDefaultMutation";
 import useAuth from "../../utils/useAuth";
-import { useForm, FormProvider } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
 import CategoryOption from "./CategoryOption";
+import { InformationCircleIcon } from "@heroicons/react/outline";
 
 interface Props {
   category: Category;
@@ -61,6 +62,12 @@ const CategoryOptions: React.FC<Props> = ({ category }) => {
 
   return (
     <div className="bg-gray-80 mt-2">
+      {!loggedUser && (
+        <div className="bg-yellow text-black p-2 flex items-center mb-2">
+          <InformationCircleIcon className="w-6 h-6 mr-1" />
+          You need to login before submit a guess
+        </div>
+      )}
       <FormProvider {...{ handleSubmit, watch, ...methods }}>
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
           {data?.data.indications.map((indication) => (


### PR DESCRIPTION
Pretty self-explanatory, if the user is not logged in, the guess request shouldn't be executed.